### PR TITLE
Use memoized image URL with cleanup

### DIFF
--- a/src/ImageViewer.tsx
+++ b/src/ImageViewer.tsx
@@ -1,11 +1,17 @@
-import React from "react"
+import React, { useEffect, useMemo } from "react"
 
 interface ImageViewerProps {
   file: File
 }
 
 const ImageViewer: React.FC<ImageViewerProps> = ({ file }) => {
-  const imageUrl = URL.createObjectURL(file)
+  const imageUrl = useMemo(() => URL.createObjectURL(file), [file])
+
+  useEffect(() => {
+    return () => {
+      URL.revokeObjectURL(imageUrl)
+    }
+  }, [imageUrl])
 
   return (
     <div className="fixed bottom-0 left-0 right-0 top-0 flex items-center justify-center">


### PR DESCRIPTION
## Summary
- ensure ImageViewer cleans up URLs

## Testing
- `yarn lint`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_685f2563d0388333ae55c8c069861928