### PR TITLE
Fix cleanup of long-touch listeners

### DIFF
--- a/src/LongTouchDiv.tsx
+++ b/src/LongTouchDiv.tsx
@@ -15,14 +15,12 @@ const LongTouchDiv: React.FC<
 
     const handleTouchEnd = () => {
       clearTimeout(timeout)
+      document.removeEventListener("mouseup", handleTouchEnd)
+      document.removeEventListener("touchend", handleTouchEnd)
     }
 
     document.addEventListener("mouseup", handleTouchEnd)
-
-    return () => {
-      clearTimeout(timeout)
-      document.removeEventListener("mouseup", handleTouchEnd)
-    }
+    document.addEventListener("touchend", handleTouchEnd)
   }
 
   return (


### PR DESCRIPTION
## Summary
- detach long-touch event listeners when finished

## Testing
- `yarn tsc -p tsconfig.json`
- `yarn lint`

------
https://chatgpt.com/codex/tasks/task_e_685f255339a08333a7d10165617f4793